### PR TITLE
chore: appending more pairs of brackets

### DIFF
--- a/src/main/kotlin/PluginMain.kt
+++ b/src/main/kotlin/PluginMain.kt
@@ -38,7 +38,13 @@ val brackets = mapOf(
     '「' to '」',
     '『' to '』',
     '《' to '》',
-    '<' to '>'
+    '<' to '>',
+    '＜' to '＞',
+    '〈' to '〉',
+    '｛' to '｝',
+    '［' to '］',
+    '／' to '＼',
+    '｟' to '｠',
 )
 
 fun analyzeBracket(msg: String) : ArrayList<Char> {


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

Appending more pairs of brackets:

-    `<` to `>`
-    `＜` to `＞`
-    `〈` to `〉`
-    `｛` to `｝`
-    `［` to `］`
-    `／` to `＼`
-  `｟` to `｠`


> They are actually hinted by github copilot.